### PR TITLE
fix: 컷 묘사 이미지 클래스 내부 데이터 양식 변경 및 프롬프트 구성 알고리즘 변경

### DIFF
--- a/consistentvideo/video/cut_image_generator.py
+++ b/consistentvideo/video/cut_image_generator.py
@@ -1,5 +1,6 @@
 from openai import OpenAI
 import base64
+import json
 from PIL import Image
 from io import BytesIO
 from base import CutImageGeneratorBase
@@ -11,9 +12,20 @@ load_dotenv()
 
 
 class CutImageGenerator(CutImageGeneratorBase):
-    def __init__(self, entity=None):        # entity = list<image, description>
+    def __init__(self, cut:dict, entity_image_path:str, entity:list=None): # cut = dict, entity = list<tuple(type, name, desc, image_path)>
+        '''
+        ex)
+        cut = {'cut_id': 1, 'description': '버스 정류장에서 버스가 도착하는 장면.', 'characters': [], 'background': '조용한 아침 거리와 버스 정류장.', 'objects': ['버스', '버스 정류장']}
+        entity = [
+        ('character', '미상(할아버지)', '{"연령대": "70~80대", "인종": "동아시아(한국인)", "성별": "남성", "헤어 스타일": "짧은 흰머리", "헤어 컬러": "백발", "신장": "165cm(추정)", "체중": "60kg(추정)", "체형": "마른 체형", "패션 스타일": "평범한 노인 복장(점퍼, 모자 등)", "추가 특징": "귀가 어두움, 고집스러움, 장난기 많음, 반복적으로 벨을 누름, 시치미 뗌"}', '미상_할아버지__front.png'), 
+        ('character', '미상(버스기사)', '{"연령대": "40~50대", "인종": "동아시아(한국인)", "성별": "남성", "헤어 스타일": "짧은 머리", "헤어 컬러": "검정 또는 흑갈색", "신장": "175cm(추정)", "체중": "75kg(추정)", "체형": "보통", "패션 스타일": "버스기사 유니폼", "추가 특징": "인내심 많으나 점점 짜증남, 유머러스함, 승객과 직접 대화"}', '미상_버스기사__front.png'), 
+        ...
+        ]
+        '''
         super().__init__(entity)
         self.ai_model = self.__create_client()
+        self.cut = cut
+        self.entity_image_path = entity_image_path
 
 
     def __create_client(self) -> OpenAI:
@@ -32,16 +44,37 @@ class CutImageGenerator(CutImageGeneratorBase):
             raise ValueError("Cut doesn't exist")
         if not self.ai_model:
             raise RuntimeError("Image generating model dosen't exist")
+        if not self.entity:
+            print("Entity list is empty") # not error
 
+        # Get cut description
+        cut_description = self.cut.get('description', '')
+
+        # Get entities that will be used
+        prompt_entity_parts = []
+        image_files = []
+
+        for e_type, name, attr_json, image_filename in self.entity:
+            try:
+                attrs = json.loads(attr_json)
+            except json.JSONDecodeError:
+                attrs = {}
+            desc = f"{e_type}: {name}. " + ", ".join([f"{k}: {v}" for k, v in attrs.items()])
+            prompt_entity_parts.append(desc)
+
+            image_path = os.path.join(self.entity_image_path, image_filename)
+            if not os.path.exists(image_path):
+                raise FileNotFoundError(f"Entity image file not found: {image_path}")
+            image_files.append(open(image_path, "rb"))
+        
         # Input prompt composing
-        prompt_descs = [desc for _, desc in self.entity]
-        cut_description = self.cut['description'] if isinstance(self.cut, dict) else str(self.cut)
-        prompt = f"{cut_description} ///// {' '.join(prompt_descs)}"
-        prompt = prompt + """
-                Based on /////, the front part is the story and the back part is the attributes in the story. 
-                And make the image describing the story by referring to the attributes needed to describe the story among the character object background attributes.
-                """
-        image_files = [open(path, "rb") for path, _ in self.entity]
+        entity_prompt = " ".join(prompt_entity_parts)
+        prompt = (
+        f"{cut_description} ///// {entity_prompt}\n"
+        "Based on /////, the front part is the story and the back part is the attributes in the story. "
+        "Make the image describing the story by referring to the attributes needed to describe the story "
+        "among the character, object, and background attributes."
+        )
     
 
         # ---------------dalle3 (can also dalle2)--------------
@@ -67,8 +100,9 @@ class CutImageGenerator(CutImageGeneratorBase):
             size="1024x1024"       # There is no size compatible 16:9, need to adjust by prompt
         )
 
+        # closing file descriptor 
         for f in image_files:
-            f.close()  # closing file descriptor 
+            f.close()  
 
         image_base64 = result.data[0].b64_json
         image_bytes = base64.b64decode(image_base64)
@@ -76,7 +110,7 @@ class CutImageGenerator(CutImageGeneratorBase):
 
         # -----------------------------------------------------
         return self.cut_image
-        # --------for test, will be deleted
+        # --------for test, will be deleted -------------------
 
 # -------------- For test ----------------------
 


### PR DESCRIPTION
- CutImageGenerator의 생성자의 매개변수에 cut, entity_image_path추가.
- cut=dictionary, entity_image_path=str, entity=list<tuple(str, str, dict,  str)>
- prompt구성 알고리즘 변경
- Entity부재시 for문 에러가 발생하니 if문으로 처리
- Entity부재시 컷 묘사 이미지 생성 방식을 edit에서 generate방식으로 교체