### PR TITLE
fix: 컷 묘사 이미지 생성함수의 반환값 조정

### DIFF
--- a/consistentvideo/video/cut_image_generator.py
+++ b/consistentvideo/video/cut_image_generator.py
@@ -125,7 +125,7 @@ class CutImageGenerator(CutImageGeneratorBase):
         os.makedirs(self.output_path, exist_ok=True)
         self.cut_image.save(save_path)
 
-        return self.cut_image
+        return save_path
         # --------for test, will be deleted -------------------
 
 # -------------- For test ----------------------

--- a/consistentvideo/video/cut_image_generator.py
+++ b/consistentvideo/video/cut_image_generator.py
@@ -12,7 +12,7 @@ load_dotenv()
 
 
 class CutImageGenerator(CutImageGeneratorBase):
-    def __init__(self, cut:dict, entity_image_path:str, entity:list=None): # cut = dict, entity = list<tuple(type, name, desc, image_path)>
+    def __init__(self, cut:dict, output_path:str, entity_image_path:str, entity:list=None): # cut = dict, entity = list<tuple(type, name, desc, image_path)>
         '''
         ex)
         cut = {'cut_id': 1, 'description': '버스 정류장에서 버스가 도착하는 장면.', 'characters': [], 'background': '조용한 아침 거리와 버스 정류장.', 'objects': ['버스', '버스 정류장']}
@@ -26,6 +26,7 @@ class CutImageGenerator(CutImageGeneratorBase):
         self.ai_model = self.__create_client()
         self.cut = cut
         self.entity_image_path = entity_image_path
+        self.output_path = output_path
 
 
     def __create_client(self) -> OpenAI:
@@ -47,8 +48,9 @@ class CutImageGenerator(CutImageGeneratorBase):
         if not self.entity:
             print("Entity list is empty") # not error
 
-        # Get cut description
+        # Get cut information
         cut_description = self.cut.get('description', '')
+        cut_id = self.cut.get("cut_id", "unknown")
 
         # Get entities that will be used
         prompt_entity_parts = []
@@ -117,6 +119,11 @@ class CutImageGenerator(CutImageGeneratorBase):
         image_base64 = result.data[0].b64_json
         image_bytes = base64.b64decode(image_base64)
         self.cut_image = Image.open(BytesIO(image_bytes))
+
+        filename = f"{cut_id}_depiction_image.png"
+        save_path = os.path.join(self.output_path, filename)
+        os.makedirs(self.output_path, exist_ok=True)
+        self.cut_image.save(save_path)
 
         return self.cut_image
         # --------for test, will be deleted -------------------


### PR DESCRIPTION
- 함수 내부에서 자동으로 저장하도록 변경
- 저장 이름은 output_path내에 f"{컷 번호}_depiction_image.png"로 설정
- 이미지 객체를 반환하는 것이 아닌 이미지 경로를 반환하도록 변경