### PR TITLE
feat: refactoring cut image generator

### DIFF
--- a/consistentvideo/video/base.py
+++ b/consistentvideo/video/base.py
@@ -106,7 +106,7 @@ class VideoPostprocessorBase(metaclass=ABCMeta):
     def ai_model(self, value):
         self.__ai_model = value
 
-class ImageGeneratorBase(metaclass=ABCMeta):
+class ImageGeneratorAIBase(metaclass=ABCMeta):
     def __init__(self):
         self.__ai_model = None
         self.__prompt_text = None
@@ -140,7 +140,7 @@ class ImageGeneratorBase(metaclass=ABCMeta):
     def prompt_images(self, value):
         self.__prompt_images = value
 
-class VideoGeneratorBase(metaclass=ABCMeta):
+class VideoGeneratorAIBase(metaclass=ABCMeta):
     def __init__(self):
         self.__ai_model = None
         self.__prompt_text = None

--- a/consistentvideo/video/base.py
+++ b/consistentvideo/video/base.py
@@ -105,3 +105,71 @@ class VideoPostprocessorBase(metaclass=ABCMeta):
     @ai_model.setter
     def ai_model(self, value):
         self.__ai_model = value
+
+class ImageGeneratorBase(metaclass=ABCMeta):
+    def __init__(self):
+        self.__ai_model = None
+        self.__prompt_text = None
+        self.__prompt_images = None
+
+    @abstractmethod
+    def execute(self):
+        pass
+
+    @property
+    def ai_model(self):
+        return self.__ai_model
+
+    @ai_model.setter
+    def ai_model(self, value):
+        self.__ai_model = value
+
+    @property
+    def prompt_text(self):
+        return self.__prompt_text
+
+    @prompt_text.setter
+    def prompt_text(self, value):
+        self.__prompt_text = value
+
+    @property
+    def prompt_images(self):
+        return self.__prompt_images
+
+    @prompt_text.setter
+    def prompt_images(self, value):
+        self.__prompt_images = value
+
+class VideoGeneratorBase(metaclass=ABCMeta):
+    def __init__(self):
+        self.__ai_model = None
+        self.__prompt_text = None
+        self.__prompt_images = None
+
+    @abstractmethod
+    def execute(self):
+        pass
+
+    @property
+    def ai_model(self):
+        return self.__ai_model
+
+    @ai_model.setter
+    def ai_model(self, value):
+        self.__ai_model = value
+
+    @property
+    def prompt_text(self):
+        return self.__prompt_text
+
+    @prompt_text.setter
+    def prompt_text(self, value):
+        self.__prompt_text = value
+
+    @property
+    def prompt_images(self):
+        return self.__prompt_images
+
+    @prompt_text.setter
+    def prompt_images(self, value):
+        self.__prompt_images = value

--- a/consistentvideo/video/cut_image_generator.py
+++ b/consistentvideo/video/cut_image_generator.py
@@ -25,6 +25,7 @@ class CutImageGenerator(CutImageGeneratorBase):
         self.output_path = output_path
         self.ai_model = ai_model
         self.cut_image_type = cut_image_type
+        self.prompt = None
 
     def execute(self):
         if not self.cut:
@@ -57,7 +58,7 @@ class CutImageGenerator(CutImageGeneratorBase):
 
         # Input prompt composing
         entity_prompt = " ".join(prompt_entity_parts)
-        prompt = (
+        self.prompt = (
             f"{cut_description} ///// {entity_prompt}\n"
             "Based on /////, the front part is the story and the back part is the attributes in the story. "
             "Make the image describing the story by referring to the attributes needed to describe the story "
@@ -70,7 +71,7 @@ class CutImageGenerator(CutImageGeneratorBase):
         
         image_generator_model = CutImageGeneratorModelSelector().call_CutImageGenerator_ai(
             self.ai_model, 
-            prompt_text = prompt, 
+            prompt_text = self.prompt, 
             prompt_images = image_paths
         )
         cut_image = image_generator_model.execute()

--- a/consistentvideo/video/cut_image_generator.py
+++ b/consistentvideo/video/cut_image_generator.py
@@ -31,7 +31,7 @@ class CutImageGenerator(CutImageGeneratorBase):
         if not self.cut:
             raise ValueError("Cut doesn't exist")
         if not self.ai_model:
-            raise RuntimeError("Image generating model dosen't exist")
+            raise ValueError("Need to select AI model")
         if not self.entity:
             print("Entity list is empty")  # not error
 
@@ -75,6 +75,10 @@ class CutImageGenerator(CutImageGeneratorBase):
             prompt_text = self.prompt, 
             prompt_images = image_paths
         )
+
+        if image_generator_model == None:
+            raise RuntimeError("Unserved Model")
+
         cut_image = image_generator_model.execute()
 
         filename = f"S{self.scene_num:04d}-C{cut_id:04d}.png"

--- a/consistentvideo/video/cut_image_generator.py
+++ b/consistentvideo/video/cut_image_generator.py
@@ -1,19 +1,14 @@
-from openai import OpenAI
-import base64
-import json
-from PIL import Image
 from io import BytesIO
 from .base import CutImageGeneratorBase
-import requests
+from .model_selector import *
 from dotenv import load_dotenv
 import os
 
 load_dotenv()
 
-
 class CutImageGenerator(CutImageGeneratorBase):
     def __init__(self, scene_num: int, cut: dict, output_path: str, entity_image_path: str,
-                 entity: list = None):  # cut = dict, entity = list<tuple(type, name, desc, image_path)>
+                 entity: list = None, ai_model: str = 'gpt'):  # cut = dict, entity = list<tuple(type, name, desc, image_path)>
         '''
         ex)
         cut = {'cut_id': 1, 'description': '버스 정류장에서 버스가 도착하는 장면.', 'characters': [], 'background': '조용한 아침 거리와 버스 정류장.', 'objects': ['버스', '버스 정류장']}
@@ -24,22 +19,11 @@ class CutImageGenerator(CutImageGeneratorBase):
         ]
         '''
         super().__init__(entity)
-        self.ai_model = self.__create_client()
         self.scene_num = scene_num
         self.cut = cut
         self.entity_image_path = entity_image_path
         self.output_path = output_path
-
-    def __create_client(self) -> OpenAI:
-        api_key = os.getenv("OPENAI_API_KEY")
-        return OpenAI(api_key=api_key)
-
-    # def __load_gpt_api_key(self) -> str:
-    #     try:
-    #         with open("api_key.txt", "r") as file:
-    #             return file.read().strip()
-    #     except FileNotFoundError:
-    #         raise RuntimeError("api key doesn't exist")
+        self.ai_model = ai_model
 
     def execute(self):
         if not self.cut:
@@ -55,27 +39,20 @@ class CutImageGenerator(CutImageGeneratorBase):
 
         # Get entities that will be used
         prompt_entity_parts = []
-        image_files = []
+        image_paths = []
 
         if self.entity:
             for e_type, name, attrs, image_filename in self.entity:
-            #     print(f"e_type={e_type}, name={name}, attrs={attrs}, image_filename={image_filename}")
-            #     print(f"self.cut.get('character', [])={self.cut.get('character', [])}")
-            #     print(f"self.cut.get('object', [])={self.cut.get('object', [])}")
-            #     print(f"self.cut.get('location', '')={self.cut.get('location', '')}")
                 if (
-                        (e_type == "character" and name in self.cut.get("character", [])) or
-                        (e_type == "object" and name in self.cut.get("object", [])) or
-                        (e_type == "location" and name == self.cut.get("location", ""))
+                    (e_type == "character" and name in self.cut.get("character", [])) or
+                    (e_type == "object" and name in self.cut.get("object", [])) or
+                    (e_type == "location" and name == self.cut.get("location", ""))
                 ):
                     desc = f"['{e_type}': '{name}', 'attribute': {attrs}]"
                     prompt_entity_parts.append(desc)
                     print(f"/////desc: {desc}")
                     image_path = os.path.join(self.entity_image_path, image_filename)
-                    if not os.path.exists(image_path):
-                        raise FileNotFoundError(f"Entity image file not found: {image_path}")
-                    image_files.append(open(image_path, "rb"))
-                    print(f"/////image_path: {image_path}")
+                    image_paths.append(image_path)
 
         # Input prompt composing
         entity_prompt = " ".join(prompt_entity_parts)
@@ -86,72 +63,20 @@ class CutImageGenerator(CutImageGeneratorBase):
             "among the character, object, and background attributes."
         )
 
-        # ---------------dalle3 (can also dalle2)--------------
-
-        # result = self.ai_model.images.generate(
-        #     model="dall-e-3",
-        #     prompt=prompt,
-        #     size="1792x1024"
-        # )
-        # image_url = result.data[0].url
-        # image_bytes = requests.get(image_url).content
-        # self.cut_image = Image.open(BytesIO(image_bytes))
-
-        # -----------------------------------------------------
-        # 
-        # ---------------------gpt-image-1---------------------
         print(f"S{self.scene_num:04d}-C{cut_id:04d}.png")
-        print(f"image_files: {image_files}")
-        if image_files:
-            result = self.ai_model.images.edit(
-                model="gpt-image-1",
-                image=image_files,
-                prompt=prompt,
-                quality="low",  # high/medium/low
-                size="1536x1024"  # There is no size compatible 16:9, need to adjust by prompt
-            )
-        else:
-            result = self.ai_model.images.generate(
-                model="gpt-image-1",
-                prompt=prompt,
-                quality="low",  # high/medium/low
-                size="1536x1024"  # There is no size compatible 16:9, need to adjust by prompt
-            )
-            # -----------------------------------------------------
-
-        # closing file descriptor 
-        for f in image_files:
-            f.close()
-
-        image_base64 = result.data[0].b64_json
-        image_bytes = base64.b64decode(image_base64)
-        self.cut_image = Image.open(BytesIO(image_bytes))
+        print(f"image_paths: {image_paths}")
+        
+        image_generator_model = CutImageGeneratorModelSelector().call_CutImageGenerator_ai(
+            self.ai_model, 
+            prompt_text = prompt, 
+            prompt_images = image_paths
+        )
+        cut_image = image_generator_model.execute()
 
         filename = f"S{self.scene_num:04d}-C{cut_id:04d}.png"
         save_path = os.path.join(self.output_path, filename)
         os.makedirs(self.output_path, exist_ok=True)
-        self.cut_image.save(save_path)
+        cut_image.save(save_path)
 
         return save_path
-        # --------for test, will be deleted -------------------
 
-# -------------- For test ----------------------
-
-# if __name__ == "__main__":
-
-#     filtered_result = [
-#     ('시내버스_front.png', '시내버스 : 크기: 대형(길이 약 10m, 40인승), 색깔: 파란색(서울 시내버스 기준, 임의), 형체: 직사각형, 창문이 큼, 카테고리: 교통수단, 태그: 대중교통, 정류장, 종점, 기사, 승객')
-#     ]
-
-#     generator = CutImageGenerator(entity=filtered_result)
-#     generator.cut = {
-#     'cut_id': 1,
-#     'description': '버스 정류장에서 버스가 도착하는 장면.',
-#     'characters': [],
-#     'background': '조용한 아침 거리와 버스 정류장.',
-#     'objects': ['버스', '버스 정류장']
-#     }
-
-#     img = generator.execute()
-#     img.show()
-#     img.save("edited_output.png")

--- a/consistentvideo/video/cut_image_generator.py
+++ b/consistentvideo/video/cut_image_generator.py
@@ -8,7 +8,7 @@ load_dotenv()
 
 class CutImageGenerator(CutImageGeneratorBase):
     def __init__(self, scene_num: int, cut: dict, output_path: str, entity_image_path: str,
-                 entity: list = None, ai_model: str = 'gpt'):  # cut = dict, entity = list<tuple(type, name, desc, image_path)>
+                 entity: list = None, ai_model: str = 'gpt', cut_image_type: str = 'reality'):  # cut = dict, entity = list<tuple(type, name, desc, image_path)>
         '''
         ex)
         cut = {'cut_id': 1, 'description': '버스 정류장에서 버스가 도착하는 장면.', 'characters': [], 'background': '조용한 아침 거리와 버스 정류장.', 'objects': ['버스', '버스 정류장']}
@@ -24,6 +24,7 @@ class CutImageGenerator(CutImageGeneratorBase):
         self.entity_image_path = entity_image_path
         self.output_path = output_path
         self.ai_model = ai_model
+        self.cut_image_type = cut_image_type
 
     def execute(self):
         if not self.cut:
@@ -61,6 +62,7 @@ class CutImageGenerator(CutImageGeneratorBase):
             "Based on /////, the front part is the story and the back part is the attributes in the story. "
             "Make the image describing the story by referring to the attributes needed to describe the story "
             "among the character, object, and background attributes."
+            f"The image should be in a {self.cut_image_type} style."
         )
 
         print(f"S{self.scene_num:04d}-C{cut_id:04d}.png")

--- a/consistentvideo/video/cut_image_generator.py
+++ b/consistentvideo/video/cut_image_generator.py
@@ -8,7 +8,7 @@ load_dotenv()
 
 class CutImageGenerator(CutImageGeneratorBase):
     def __init__(self, scene_num: int, cut: dict, output_path: str, entity_image_path: str,
-                 entity: list = None, ai_model: str = 'gpt', cut_image_type: str = 'reality'):  # cut = dict, entity = list<tuple(type, name, desc, image_path)>
+                 entity: list = None, ai_model: str = 'gpt'):  # cut = dict, entity = list<tuple(type, name, desc, image_path)>
         '''
         ex)
         cut = {'cut_id': 1, 'description': '버스 정류장에서 버스가 도착하는 장면.', 'characters': [], 'background': '조용한 아침 거리와 버스 정류장.', 'objects': ['버스', '버스 정류장']}
@@ -24,8 +24,8 @@ class CutImageGenerator(CutImageGeneratorBase):
         self.entity_image_path = entity_image_path
         self.output_path = output_path
         self.ai_model = ai_model
-        self.cut_image_type = cut_image_type
         self.prompt = None
+        self.cut_image_type_prompt = "The image should be in a reality style."
 
     def execute(self):
         if not self.cut:
@@ -58,12 +58,13 @@ class CutImageGenerator(CutImageGeneratorBase):
 
         # Input prompt composing
         entity_prompt = " ".join(prompt_entity_parts)
+        
         self.prompt = (
             f"{cut_description} ///// {entity_prompt}\n"
             "Based on /////, the front part is the story and the back part is the attributes in the story. "
             "Make the image describing the story by referring to the attributes needed to describe the story "
             "among the character, object, and background attributes."
-            f"The image should be in a {self.cut_image_type} style."
+            f"{self.cut_image_type_prompt}"
         )
 
         print(f"S{self.scene_num:04d}-C{cut_id:04d}.png")

--- a/consistentvideo/video/model_selector.py
+++ b/consistentvideo/video/model_selector.py
@@ -13,12 +13,14 @@ class CutImageGeneratorModelSelector:
     def call_CutImageGenerator_ai(self, ai_model : str, prompt_text : str = None, prompt_images : list = None):
         if ai_model == "gemini":
             return ImageGeneratorModelGemini(prompt_text = prompt_text, prompt_images = prompt_images)
-        elif ai_model == "gpt":
+        elif ai_model == "gpt-image-1":
             return ImageGeneratorModelGPT_image_1(prompt_text = prompt_text, prompt_images = prompt_images)
+        elif ai_model == "dalle3":
+            return ImageGeneratorModelDalle3(prompt_text = prompt_text, prompt_images = prompt_images)
         else:
             return None
         
-        
+
 class ImageGeneratorModelGemini(ImageGeneratoAIBase):
     '''
     Need to fill this blank with Gemini version model

--- a/consistentvideo/video/model_selector.py
+++ b/consistentvideo/video/model_selector.py
@@ -1,0 +1,79 @@
+from .base import ImageGeneratorBase, VideoGeneratorBase
+import os
+from openai import OpenAI
+import requests
+from PIL import Image
+from io import BytesIO
+
+class CutImageGeneratorModelSelector:
+    def __init__(self):
+        pass
+
+    def call_CutImageGenerator_ai(self, ai_model : str, prompt_text : str = None, prompt_images : list = None):
+        if ai_model == "gemini":
+            return ImageGeneratorModelGemini(prompt_text = prompt_text, prompt_images = prompt_images)
+        elif ai_model == "gpt":
+            return ImageGeneratorModelGPT(prompt_text = prompt_text, prompt_images = prompt_images)
+        else:
+            return None
+        
+class ImageGeneratorModelGemini(ImageGeneratorBase):
+    '''
+    Need to fill this blank with Gemini version model
+    '''
+    def __init__(self, prompt_text : str = None, prompt_images : list = None):
+        pass
+
+    def execute(self):
+        pass
+    
+
+
+class ImageGeneratorModelGPT(ImageGeneratorBase):
+    def __init__(self, prompt_text : str = None, prompt_images : list = None):
+        api_key = os.getenv("OPENAI_API_KEY")
+        super.ai_model = OpenAI(api_key=api_key)
+        super.prompt_text = prompt_text
+        super.prompt_images = prompt_images
+
+    def execute(self):
+        # ---------------dalle3 (can also dalle2)--------------
+
+        result = super.ai_model.images.generate(
+            model="dall-e-3",
+            prompt=super.prompt_text,
+            size="1792x1024"
+        )
+        image_url = result.data[0].url
+        image_bytes = requests.get(image_url).content
+        cut_image = Image.open(BytesIO(image_bytes))
+
+        # -----------------------------------------------------
+        # 
+        # ---------------------gpt-image-1---------------------
+        print(f"S{self.scene_num:04d}-C{cut_id:04d}.png")
+        print(f"image_files: {image_files}")
+        if image_files:
+            result = self.ai_model.images.edit(
+                model="gpt-image-1",
+                image=image_files,
+                prompt=prompt,
+                quality="low",  # high/medium/low
+                size="1536x1024"  # There is no size compatible 16:9, need to adjust by prompt
+            )
+        else:
+            result = self.ai_model.images.generate(
+                model="gpt-image-1",
+                prompt=prompt,
+                quality="low",  # high/medium/low
+                size="1536x1024"  # There is no size compatible 16:9, need to adjust by prompt
+            )
+        # -----------------------------------------------------
+
+
+# -------------------------------------------------------------------------------------------
+
+class VideoGeneratorModelSelector:
+    def __init__(self):
+        pass
+

--- a/consistentvideo/video/model_selector.py
+++ b/consistentvideo/video/model_selector.py
@@ -1,4 +1,4 @@
-from .base import ImageGeneratorBase, VideoGeneratorBase
+from .base import ImageGeneratoAIBase, VideoGeneratorAIBase
 import os
 from openai import OpenAI
 import base64
@@ -14,11 +14,12 @@ class CutImageGeneratorModelSelector:
         if ai_model == "gemini":
             return ImageGeneratorModelGemini(prompt_text = prompt_text, prompt_images = prompt_images)
         elif ai_model == "gpt":
-            return ImageGeneratorModelGPT(prompt_text = prompt_text, prompt_images = prompt_images)
+            return ImageGeneratorModelGPT_image_1(prompt_text = prompt_text, prompt_images = prompt_images)
         else:
             return None
         
-class ImageGeneratorModelGemini(ImageGeneratorBase):
+        
+class ImageGeneratorModelGemini(ImageGeneratoAIBase):
     '''
     Need to fill this blank with Gemini version model
     '''
@@ -29,8 +30,7 @@ class ImageGeneratorModelGemini(ImageGeneratorBase):
         pass
     
 
-
-class ImageGeneratorModelGPT(ImageGeneratorBase):
+class ImageGeneratorModelDalle3(ImageGeneratoAIBase):
     def __init__(self, prompt_text : str = None, prompt_images : list = None):
         api_key = os.getenv("OPENAI_API_KEY")
         super.ai_model = OpenAI(api_key=api_key)
@@ -48,17 +48,36 @@ class ImageGeneratorModelGPT(ImageGeneratorBase):
 
         # ---------------dalle3 (can also dalle2)--------------
 
-        # result = super.ai_model.images.generate(
-        #     model="dall-e-3",
-        #     prompt=super.prompt_text,
-        #     size="1792x1024"
-        # )
-        # image_url = result.data[0].url
-        # image_bytes = requests.get(image_url).content
-        # cut_image = Image.open(BytesIO(image_bytes))
+        result = super.ai_model.images.generate(
+            model="dall-e-3",
+            prompt=super.prompt_text,
+            size="1792x1024"
+        )
+        image_url = result.data[0].url
+        image_bytes = requests.get(image_url).content
+        cut_image = Image.open(BytesIO(image_bytes))
 
         # -----------------------------------------------------
-        # 
+
+        return cut_image
+    
+
+class ImageGeneratorModelGPT_image_1(ImageGeneratoAIBase):
+    def __init__(self, prompt_text : str = None, prompt_images : list = None):
+        api_key = os.getenv("OPENAI_API_KEY")
+        super.ai_model = OpenAI(api_key=api_key)
+        super.prompt_text = prompt_text
+        super.prompt_images = prompt_images
+
+    def execute(self):
+
+        image_files = []
+        for prompt_image_path in super.prompt_images:
+            if not os.path.exists(prompt_image_path):
+                raise FileNotFoundError(f"Entity image file not found: {prompt_image_path}")
+            image_files.append(open(prompt_image_path, "rb"))
+            # print(f"/////image_path: {prompt_image_path}")
+
         # ---------------------gpt-image-1---------------------
         if image_files:
             result = self.ai_model.images.edit(
@@ -87,6 +106,7 @@ class ImageGeneratorModelGPT(ImageGeneratorBase):
         return cut_image
 
 # -------------------------------------------------------------------------------------------
+
 
 class VideoGeneratorModelSelector:
     def __init__(self):


### PR DESCRIPTION
1. consistentvideo\video\base.py 파일에 ImageGeneratorBase, VideoGeneratorBase추가
2. consistentvideo\video\model_selector.py파일 생성
3. consistentvideo\video\model_selector.py파일에 CutImageGeneratorModelSelector, VideoGeneratorModelSelector추가
4. CutImageGeneratorModelSelector 내부 구현 완료

5. consistentvideo\video\model_selector.py의 ImageGeneratorModelGPT에 이미지 생성 알고리즘 이동 및 수정(dalle3파트 수정, gpt-image-1파트 수정)

6. cut_image_generator.py내 이미지 생성 알고리즘 삭제(프롬프트 구성 알고리즘만 존재)
7. 사용되지 않는 주석 삭제
8. CutImageGenerator내 __create_client메서드 삭제
9. Entity정보 추출 알고리즘에서 image descriptor생성 로직 삭제 및 image path 생성 로직 추가
10. model_selector.py의 CutImageGeneratorModelSelector의 call_CutImageGenerator_ai로부터 원하는 모델 생성 기능 추가

11. CutImageGenerator클래스 내 cut image type 변수 추가
12. 최종 prompt구성 단계에서 cut image type적용
